### PR TITLE
Allow single quotes to form a docblock for python

### DIFF
--- a/src/Lichen/Lexer/Python.hs
+++ b/src/Lichen/Lexer/Python.hs
@@ -32,7 +32,7 @@ data Tok = False | None | True | And | As | Assert | Break | Class | Continue
 instance Hashable Tok
 
 sc :: Parser ()
-sc = L.space (void spaceChar) (L.skipLineComment "#") (L.skipBlockComment "\"\"\"" "\"\"\"")
+sc = L.space (void spaceChar) (L.skipLineComment "#") (L.skipBlockComment "\"\"\"" "\"\"\"" <|> L.skipBlockComment "'''" "'''")
 
 onetoken :: Parser (Tagged Tok)
 onetoken = wrap (reserved "False") Lichen.Lexer.Python.False


### PR DESCRIPTION
The current version will fail if a student uses single quote docblocks, and then a single quote within that docblock as the parser does not recognize that as a multiline comment that should be ignored when parsing.

An example of this would be:
```python
'''
Some test comment that I'd like to see pass
'''
first = input("Enter the first number: ")
print(first)
if float(first) < 5:
    print('Below five')
else:
    print('Above file')
```

where running:
`count --language python token If test.py` should output 1 (currently outputs 0)